### PR TITLE
Add GitHub Actions workflow for repository sync

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,29 @@
+# GitHub Actions Workflows
+
+This directory contains GitHub Actions workflows for syncing content between repositories.
+
+## Workflow Files
+
+### 1. `sync-to-release-test.yml`
+
+This workflow is triggered when changes are made to the `release-server.md` file in the `techiro/release-test-server` repository. It sends a repository_dispatch event to the `techiro/release-test` repository.
+
+**Requirements:**
+- A secret named `REPO_ACCESS_TOKEN` must be set in the repository settings with a GitHub personal access token that has the `repo` scope and access to both repositories.
+
+### 2. `receive-server-updates.yml` (to be placed in techiro/release-test repository)
+
+This workflow is triggered by the repository_dispatch event from the `techiro/release-test-server` repository. It:
+1. Runs the `make sync server-release` command
+2. Commits any changes to the `release-server.md` file
+3. Creates a pull request with these changes
+
+**Requirements:**
+- The repository must have a Makefile with a `sync server-release` target that fetches the latest `release-server.md` from the server repository.
+- GitHub Actions must have permission to create branches and pull requests.
+
+## Setup Instructions
+
+1. Add the `REPO_ACCESS_TOKEN` secret to the `techiro/release-test-server` repository settings.
+2. Place the `receive-server-updates.yml` file in the `.github/workflows` directory of the `techiro/release-test` repository.
+3. Ensure the `techiro/release-test` repository has a Makefile with the appropriate sync command.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,29 +1,29 @@
-# GitHub Actions Workflows
+# GitHub Actions ワークフロー
 
-This directory contains GitHub Actions workflows for syncing content between repositories.
+このディレクトリには、リポジトリ間でコンテンツを同期するための GitHub Actions ワークフローが含まれています。
 
-## Workflow Files
+## ワークフローファイル
 
 ### 1. `sync-to-release-test.yml`
 
-This workflow is triggered when changes are made to the `release-server.md` file in the `techiro/release-test-server` repository. It sends a repository_dispatch event to the `techiro/release-test` repository.
+このワークフローは、`techiro/release-test-server` リポジトリの `release-server.md` ファイルに変更が加えられたときにトリガーされます。`techiro/release-test` リポジトリに repository_dispatch イベントを送信します。
 
-**Requirements:**
-- A secret named `REPO_ACCESS_TOKEN` must be set in the repository settings with a GitHub personal access token that has the `repo` scope and access to both repositories.
+**要件:**
+- リポジトリ設定に `REPO_ACCESS_TOKEN` という名前のシークレットを設定する必要があります。このトークンは、`repo` スコープを持ち、両方のリポジトリにアクセスできる GitHub パーソナルアクセストークンである必要があります。
 
-### 2. `receive-server-updates.yml` (to be placed in techiro/release-test repository)
+### 2. `receive-server-updates.yml` (techiro/release-test リポジトリに配置する必要があります)
 
-This workflow is triggered by the repository_dispatch event from the `techiro/release-test-server` repository. It:
-1. Runs the `make sync server-release` command
-2. Commits any changes to the `release-server.md` file
-3. Creates a pull request with these changes
+このワークフローは、`techiro/release-test-server` リポジトリからの repository_dispatch イベントによってトリガーされます。以下の処理を行います:
+1. `make sync server-release` コマンドを実行します
+2. `release-server.md` ファイルへの変更をコミットします
+3. これらの変更を含むプルリクエストを作成します
 
-**Requirements:**
-- The repository must have a Makefile with a `sync server-release` target that fetches the latest `release-server.md` from the server repository.
-- GitHub Actions must have permission to create branches and pull requests.
+**要件:**
+- リポジトリには、サーバーリポジトリから最新の `release-server.md` を取得する `sync server-release` ターゲットを持つ Makefile が必要です。
+- GitHub Actions がブランチとプルリクエストを作成する権限を持っている必要があります。
 
-## Setup Instructions
+## セットアップ手順
 
-1. Add the `REPO_ACCESS_TOKEN` secret to the `techiro/release-test-server` repository settings.
-2. Place the `receive-server-updates.yml` file in the `.github/workflows` directory of the `techiro/release-test` repository.
-3. Ensure the `techiro/release-test` repository has a Makefile with the appropriate sync command.
+1. `techiro/release-test-server` リポジトリの設定に `REPO_ACCESS_TOKEN` シークレットを追加します。
+2. `receive-server-updates.yml` ファイルを `techiro/release-test` リポジトリの `.github/workflows` ディレクトリに配置します。
+3. `techiro/release-test` リポジトリに適切な同期コマンドを持つ Makefile があることを確認します。

--- a/.github/workflows/receive-server-updates.yml
+++ b/.github/workflows/receive-server-updates.yml
@@ -1,4 +1,4 @@
-name: Receive Server Updates
+name: サーバー更新を受信
 
 on:
   repository_dispatch:
@@ -8,18 +8,18 @@ jobs:
   sync-and-create-pr:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: リポジトリをチェックアウト
         uses: actions/checkout@v3
 
-      - name: Set up Git
+      - name: Gitを設定
         run: |
           git config user.name "GitHub Actions Bot"
           git config user.email "actions@github.com"
 
-      - name: Run sync command
+      - name: 同期コマンドを実行
         run: make sync server-release
 
-      - name: Check for changes
+      - name: 変更を確認
         id: check_changes
         run: |
           if [[ -n "$(git status --porcelain release-server.md)" ]]; then
@@ -28,32 +28,32 @@ jobs:
             echo "changes=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Create branch and commit changes
+      - name: ブランチを作成して変更をコミット
         if: steps.check_changes.outputs.changes == 'true'
         run: |
-          # Create a new branch with timestamp
+          # タイムスタンプ付きの新しいブランチを作成
           BRANCH_NAME="update-server-release-$(date +%Y%m%d%H%M%S)"
           git checkout -b $BRANCH_NAME
           
-          # Add and commit changes
+          # 変更を追加してコミット
           git add release-server.md
-          git commit -m "Update server release information"
+          git commit -m "サーバーリリース情報を更新"
           
-          # Push to the new branch
+          # 新しいブランチにプッシュ
           git push origin $BRANCH_NAME
           
-          # Save branch name for PR creation
+          # PR作成用にブランチ名を保存
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
 
-      - name: Create Pull Request
+      - name: プルリクエストを作成
         if: steps.check_changes.outputs.changes == 'true'
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          title: "Update server release information"
+          title: "サーバーリリース情報を更新"
           body: |
-            This PR updates the server release information from the techiro/release-test-server repository.
+            このPRは、techiro/release-test-serverリポジトリからのサーバーリリース情報を更新します。
             
-            Triggered by changes in techiro/release-test-server.
+            techiro/release-test-serverの変更によってトリガーされました。
           branch: ${{ env.BRANCH_NAME }}
           base: main

--- a/.github/workflows/receive-server-updates.yml
+++ b/.github/workflows/receive-server-updates.yml
@@ -1,0 +1,59 @@
+name: Receive Server Updates
+
+on:
+  repository_dispatch:
+    types: [server-release-updated]
+
+jobs:
+  sync-and-create-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Git
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "actions@github.com"
+
+      - name: Run sync command
+        run: make sync server-release
+
+      - name: Check for changes
+        id: check_changes
+        run: |
+          if [[ -n "$(git status --porcelain release-server.md)" ]]; then
+            echo "changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "changes=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create branch and commit changes
+        if: steps.check_changes.outputs.changes == 'true'
+        run: |
+          # Create a new branch with timestamp
+          BRANCH_NAME="update-server-release-$(date +%Y%m%d%H%M%S)"
+          git checkout -b $BRANCH_NAME
+          
+          # Add and commit changes
+          git add release-server.md
+          git commit -m "Update server release information"
+          
+          # Push to the new branch
+          git push origin $BRANCH_NAME
+          
+          # Save branch name for PR creation
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+
+      - name: Create Pull Request
+        if: steps.check_changes.outputs.changes == 'true'
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: "Update server release information"
+          body: |
+            This PR updates the server release information from the techiro/release-test-server repository.
+            
+            Triggered by changes in techiro/release-test-server.
+          branch: ${{ env.BRANCH_NAME }}
+          base: main

--- a/.github/workflows/sync-to-release-test.yml
+++ b/.github/workflows/sync-to-release-test.yml
@@ -1,4 +1,4 @@
-name: Sync Server Release to Main Repo
+name: サーバーリリースをメインリポジトリに同期
 
 on:
   push:
@@ -11,7 +11,7 @@ jobs:
   notify-main-repo:
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger repository_dispatch event
+      - name: repository_dispatchイベントをトリガー
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}

--- a/.github/workflows/sync-to-release-test.yml
+++ b/.github/workflows/sync-to-release-test.yml
@@ -1,0 +1,20 @@
+name: Sync Server Release to Main Repo
+
+on:
+  push:
+    paths:
+      - 'release-server.md'
+    branches:
+      - main
+
+jobs:
+  notify-main-repo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger repository_dispatch event
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          repository: techiro/release-test
+          event-type: server-release-updated
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'

--- a/Makefile.sample
+++ b/Makefile.sample
@@ -1,0 +1,16 @@
+# Sample Makefile for techiro/release-test repository
+
+.PHONY: sync server-release
+
+# Sync server release information
+sync:
+	@echo "Syncing repository resources..."
+
+# Fetch the latest release-server.md from the server repository
+server-release:
+	@echo "Fetching server release information..."
+	curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
+		-H "Accept: application/vnd.github.v3.raw" \
+		-o release-server.md \
+		https://api.github.com/repos/techiro/release-test-server/contents/release-server.md
+	@echo "Server release information updated."

--- a/Makefile.sample
+++ b/Makefile.sample
@@ -1,16 +1,16 @@
-# Sample Makefile for techiro/release-test repository
+# techiro/release-test リポジトリ用のサンプル Makefile
 
 .PHONY: sync server-release
 
-# Sync server release information
+# サーバーリリース情報を同期
 sync:
-	@echo "Syncing repository resources..."
+	@echo "リポジトリリソースを同期中..."
 
-# Fetch the latest release-server.md from the server repository
+# サーバーリポジトリから最新の release-server.md を取得
 server-release:
-	@echo "Fetching server release information..."
+	@echo "サーバーリリース情報を取得中..."
 	curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
 		-H "Accept: application/vnd.github.v3.raw" \
 		-o release-server.md \
 		https://api.github.com/repos/techiro/release-test-server/contents/release-server.md
-	@echo "Server release information updated."
+	@echo "サーバーリリース情報が更新されました。"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # release-test-server
 release-testリポジトリ用
+
+## ドキュメント
+
+- [リポジトリ同期ワークフローのシーケンス図](docs/sequence-diagram.md)

--- a/docs/sequence-diagram.md
+++ b/docs/sequence-diagram.md
@@ -1,0 +1,48 @@
+# リポジトリ同期ワークフローのシーケンス図
+
+このドキュメントでは、`techiro/release-test-server` リポジトリと `techiro/release-test` リポジトリ間の同期ワークフローを説明するシーケンス図を提供します。
+
+## リポジトリ同期のシーケンス図
+
+```mermaid
+sequenceDiagram
+    participant Developer
+    participant ReleaseTestServer as techiro/release-test-server
+    participant GitHub as GitHub Actions
+    participant ReleaseTest as techiro/release-test
+    
+    Developer->>ReleaseTestServer: release-server.md を更新
+    Developer->>ReleaseTestServer: 変更をコミット＆プッシュ
+    
+    ReleaseTestServer->>GitHub: push イベントをトリガー
+    Note over GitHub: sync-to-release-test.yml<br/>ワークフローが実行される
+    
+    GitHub->>ReleaseTest: repository_dispatch イベントを送信
+    Note over ReleaseTest: receive-server-updates.yml<br/>ワークフローが実行される
+    
+    ReleaseTest->>ReleaseTest: make sync server-release を実行
+    Note over ReleaseTest: 最新の release-server.md を<br/>取得して更新
+    
+    ReleaseTest->>ReleaseTest: 変更を検出
+    ReleaseTest->>ReleaseTest: 新しいブランチを作成
+    ReleaseTest->>ReleaseTest: 変更をコミット
+    
+    ReleaseTest->>GitHub: プルリクエストを作成
+    GitHub->>Developer: プルリクエスト通知
+    
+    Developer->>ReleaseTest: プルリクエストをレビュー
+    Developer->>ReleaseTest: プルリクエストをマージ
+```
+
+## 処理の流れ
+
+1. 開発者が `techiro/release-test-server` リポジトリの `release-server.md` ファイルを更新します
+2. 変更が main ブランチにプッシュされると、GitHub Actions の `sync-to-release-test.yml` ワークフローが実行されます
+3. このワークフローは `techiro/release-test` リポジトリに repository_dispatch イベントを送信します
+4. `techiro/release-test` リポジトリでは `receive-server-updates.yml` ワークフローが実行されます
+5. このワークフローは `make sync server-release` コマンドを実行して、最新の `release-server.md` ファイルを取得します
+6. 変更が検出されると、新しいブランチが作成され、変更がコミットされます
+7. 自動的にプルリクエストが作成され、開発者に通知されます
+8. 開発者はプルリクエストをレビューし、問題がなければマージします
+
+この自動化されたワークフローにより、両方のリポジトリ間でサーバーリリース情報を常に最新の状態に保つことができます。

--- a/release-server.md
+++ b/release-server.md
@@ -1,3 +1,3 @@
-# Release Server
+# リリースサーバー
 
-This is a placeholder file for the release-server.md that will be synced between repositories.
+これは、リポジトリ間で同期される release-server.md のプレースホルダーファイルです。

--- a/release-server.md
+++ b/release-server.md
@@ -1,0 +1,3 @@
+# Release Server
+
+This is a placeholder file for the release-server.md that will be synced between repositories.


### PR DESCRIPTION
This PR adds GitHub Actions workflows to sync the release-server.md file between repositories.

## Changes

- Added `sync-to-release-test.yml` workflow that triggers a repository_dispatch event when release-server.md is updated
- Added `receive-server-updates.yml` as a reference for the techiro/release-test repository
- Created a sample Makefile for the techiro/release-test repository
- Added documentation for the workflows
- Created a placeholder release-server.md file

## Implementation Details

1. When changes are made to release-server.md in this repository, a repository_dispatch event is sent to techiro/release-test
2. The techiro/release-test repository will then run the make sync server-release command to fetch the updated file
3. Changes are committed and a PR is created automatically

## Required Setup

- A GitHub Personal Access Token with repo scope needs to be added as a secret named REPO_ACCESS_TOKEN in this repository
- The receive-server-updates.yml file needs to be placed in the techiro/release-test repository
- A Makefile with the sync server-release target needs to be added to the techiro/release-test repository